### PR TITLE
Add option to output non-pretty / compact json

### DIFF
--- a/logger/src/main/resources/logging.conf
+++ b/logger/src/main/resources/logging.conf
@@ -32,6 +32,7 @@ com.persist {
         // Print summary counts when logger is closed
         summary = true
         // pretty output - multiple line json
+        pretty = true
       }
     }
     // Log level for logger API

--- a/logger/src/main/resources/logging.conf
+++ b/logger/src/main/resources/logging.conf
@@ -31,6 +31,7 @@ com.persist {
         width = 80
         // Print summary counts when logger is closed
         summary = true
+        // pretty output - multiple line json
       }
     }
     // Log level for logger API

--- a/logger/src/main/scala/com/persist/logging/StdOutAppender.scala
+++ b/logger/src/main/scala/com/persist/logging/StdOutAppender.scala
@@ -32,6 +32,7 @@ class StdOutAppender(factory: ActorRefFactory, stdHeaders: Map[String, RichMsg])
   private[this] val color = config.getBoolean("color")
   private[this] val width = config.getInt("width")
   private[this] val summary = config.getBoolean("summary")
+  private[this] val pretty = config.getBoolean("pretty")
   private[this] var categories = Map.empty[String, Int]
   private[this] var levels = Map.empty[String, Int]
   private[this] var kinds = Map.empty[String, Int]
@@ -54,7 +55,11 @@ class StdOutAppender(factory: ActorRefFactory, stdHeaders: Map[String, RichMsg])
         }
       }
       val msg = if (fullHeaders) stdHeaders ++ baseMsg else baseMsg
-      val txt = Pretty(msg - "@category", safe = true, width = width)
+      val txt = if (pretty)
+        Pretty(msg - "@category", safe = true, width = width)
+      else
+        Compact(msg - "@category", safe = true)
+
       val colorTxt = if (color) {
         level match {
           case "FATAL" | "ERROR" =>


### PR DESCRIPTION
A lot of tools (jq) in particular works particularly well if all the logs are single lined output. This change adds the ability to request "non-pretty" json as output.